### PR TITLE
태그 생성 시 벌크연산으로 수정

### DIFF
--- a/src/main/java/f3f/dev1/domain/post/api/PostController.java
+++ b/src/main/java/f3f/dev1/domain/post/api/PostController.java
@@ -61,6 +61,13 @@ public class PostController {
     }
 
 
+    /**
+     * 태그를 포함해서 검색하는 api와 포함하지 않고 검색하는 api를 분리하는 이유는 프론트 측에서 아예 이 둘이 별도의 기능으로 제공되기 때문이다.
+     * @param tagNames
+     * @param trade
+     * @param pageable
+     * @return
+     */
     @GetMapping(value = "/post/tagSearch")
     public ResponseEntity<Page<PostSearchResponseDto>> getPostsWithTagNames(
             @RequestParam(value = "tags", required = false, defaultValue = "") List<String> tagNames,

--- a/src/main/java/f3f/dev1/domain/post/model/Post.java
+++ b/src/main/java/f3f/dev1/domain/post/model/Post.java
@@ -27,7 +27,7 @@ import static f3f.dev1.domain.post.dto.PostDTO.*;
 @Entity
 public class Post extends BaseTimeEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
     private Long id;
 

--- a/src/main/java/f3f/dev1/domain/tag/application/TagService.java
+++ b/src/main/java/f3f/dev1/domain/tag/application/TagService.java
@@ -16,11 +16,13 @@ import f3f.dev1.domain.tag.model.Tag;
 import f3f.dev1.global.error.exception.NotFoundByIdException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static f3f.dev1.domain.post.dto.PostDTO.*;
 import static f3f.dev1.domain.tag.dto.TagDTO.*;
@@ -72,30 +74,39 @@ public class TagService {
         return postTag.getId();
     }
 
+//    @Transactional
+//    public Long addTagsToPost(Long postId, List<String> tagNames) {
+//        Post post = postRepository.findById(postId).orElseThrow(NotFoundByIdException::new);
+//        // 전체를 bulk native query로 변경하겠다.
+//        // 전달 받은 tagNames에서 데이터베이스에 존재하지 않는 태그명만 골라 태그에 삽입.
+//        // 이후에 전체를 postTag에 넣어준다.
+//        // 그럼 게시글 수정에는?
+//        if(!tagNames.isEmpty()){
+//            for (String tagName : tagNames) {
+//                if(!tagRepository.existsByName(tagName)) {
+//                    // 게시글에서 받아온 태그가 현재 없는 태그면 자동으로 만들어 줘야 한다.
+//                    Tag tag = Tag.builder().name(tagName).build();
+//                    tagRepository.save(tag);
+//                    // 태그 저장 후 곧바로 postTag 만들어 추가해주기.
+//                    PostTag postTag = PostTag.builder().post(post).tag(tag).build();
+//                    postTagRepository.save(postTag);
+//                } else {
+//                    // 태그가 존재한다면 값을 받아와서 postTag로 만든 뒤 저장해준다.
+//                    Tag tag = tagRepository.findByName(tagName).orElseThrow(NotFoundByTagNameException::new);
+//                    PostTag postTag = PostTag.builder().post(post).tag(tag).build();
+//                    postTagRepository.save(postTag);
+//                }
+//            }
+//        }
+//        return post.getId();
+//    }
+
     @Transactional
-    public Long addTagsToPost(Long postId, List<String> tagNames) {
+    public void addTagsToPost(Long postId, List<String> tagNames) {
         Post post = postRepository.findById(postId).orElseThrow(NotFoundByIdException::new);
-        if(tagNames.isEmpty()) {
-            // 추가한 태그가 없다면 바로 게시글을 생성해도 된다.
-            return post.getId();
-        } else {
-            for (String tagName : tagNames) {
-                if(!tagRepository.existsByName(tagName)) {
-                    // 게시글에서 받아온 태그가 현재 없는 태그면 자동으로 만들어 줘야 한다.
-                    Tag tag = Tag.builder().name(tagName).build();
-                    tagRepository.save(tag);
-                    // 태그 저장 후 곧바로 postTag 만들어 추가해주기.
-                    PostTag postTag = PostTag.builder().post(post).tag(tag).build();
-                    postTagRepository.save(postTag);
-                } else {
-                    // 태그가 존재한다면 값을 받아와서 postTag로 만든 뒤 저장해준다.
-                    Tag tag = tagRepository.findByName(tagName).orElseThrow(NotFoundByTagNameException::new);
-                    PostTag postTag = PostTag.builder().post(post).tag(tag).build();
-                    postTagRepository.save(postTag);
-                }
-            }
-            return post.getId();
-        }
+        tagRepository.tagBulkInsert(tagNames);
+        List<Long> tagsId = tagRepository.findByNameIn(tagNames).stream().map(tag -> tag.getId()).collect(Collectors.toList());
+        postTagRepository.postTagBulkInsert(post.getId(), tagsId);
     }
 
     /*
@@ -209,5 +220,5 @@ public class TagService {
         태그는 업데이트가 필요 없어보인다.
         게시글에 들어가는 태그는 삭제 후 재생성이 일반적이기 때문
      */
-    
+
 }

--- a/src/main/java/f3f/dev1/domain/tag/application/TagService.java
+++ b/src/main/java/f3f/dev1/domain/tag/application/TagService.java
@@ -10,13 +10,11 @@ import f3f.dev1.domain.post.model.ScrapPost;
 import f3f.dev1.domain.tag.dao.PostTagRepository;
 import f3f.dev1.domain.tag.dao.TagRepository;
 import f3f.dev1.domain.tag.exception.DuplicateTagException;
-import f3f.dev1.domain.tag.exception.NotFoundByTagNameException;
 import f3f.dev1.domain.tag.model.PostTag;
 import f3f.dev1.domain.tag.model.Tag;
 import f3f.dev1.global.error.exception.NotFoundByIdException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -74,39 +72,13 @@ public class TagService {
         return postTag.getId();
     }
 
-//    @Transactional
-//    public Long addTagsToPost(Long postId, List<String> tagNames) {
-//        Post post = postRepository.findById(postId).orElseThrow(NotFoundByIdException::new);
-//        // 전체를 bulk native query로 변경하겠다.
-//        // 전달 받은 tagNames에서 데이터베이스에 존재하지 않는 태그명만 골라 태그에 삽입.
-//        // 이후에 전체를 postTag에 넣어준다.
-//        // 그럼 게시글 수정에는?
-//        if(!tagNames.isEmpty()){
-//            for (String tagName : tagNames) {
-//                if(!tagRepository.existsByName(tagName)) {
-//                    // 게시글에서 받아온 태그가 현재 없는 태그면 자동으로 만들어 줘야 한다.
-//                    Tag tag = Tag.builder().name(tagName).build();
-//                    tagRepository.save(tag);
-//                    // 태그 저장 후 곧바로 postTag 만들어 추가해주기.
-//                    PostTag postTag = PostTag.builder().post(post).tag(tag).build();
-//                    postTagRepository.save(postTag);
-//                } else {
-//                    // 태그가 존재한다면 값을 받아와서 postTag로 만든 뒤 저장해준다.
-//                    Tag tag = tagRepository.findByName(tagName).orElseThrow(NotFoundByTagNameException::new);
-//                    PostTag postTag = PostTag.builder().post(post).tag(tag).build();
-//                    postTagRepository.save(postTag);
-//                }
-//            }
-//        }
-//        return post.getId();
-//    }
 
     @Transactional
     public void addTagsToPost(Long postId, List<String> tagNames) {
         Post post = postRepository.findById(postId).orElseThrow(NotFoundByIdException::new);
-        tagRepository.tagBulkInsert(tagNames);
+        tagRepository.saveTagWithBulk(tagNames);
         List<Long> tagsId = tagRepository.findByNameIn(tagNames).stream().map(tag -> tag.getId()).collect(Collectors.toList());
-        postTagRepository.postTagBulkInsert(post.getId(), tagsId);
+        postTagRepository.savePostTagWithBulk(post.getId(), tagsId);
     }
 
     /*

--- a/src/main/java/f3f/dev1/domain/tag/dao/PostTagCustomRepository.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/PostTagCustomRepository.java
@@ -1,10 +1,7 @@
 package f3f.dev1.domain.tag.dao;
 
-import f3f.dev1.domain.post.model.Post;
-import f3f.dev1.domain.tag.model.Tag;
-
 import java.util.List;
 
 public interface PostTagCustomRepository {
-  void postTagBulkInsert(Long postId, List<Long> tagsId);
+  void savePostTagWithBulk(Long postId, List<Long> tagsId);
 }

--- a/src/main/java/f3f/dev1/domain/tag/dao/PostTagCustomRepository.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/PostTagCustomRepository.java
@@ -1,0 +1,10 @@
+package f3f.dev1.domain.tag.dao;
+
+import f3f.dev1.domain.post.model.Post;
+import f3f.dev1.domain.tag.model.Tag;
+
+import java.util.List;
+
+public interface PostTagCustomRepository {
+  void postTagBulkInsert(Long postId, List<Long> tagsId);
+}

--- a/src/main/java/f3f/dev1/domain/tag/dao/PostTagCustomRepositoryImpl.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/PostTagCustomRepositoryImpl.java
@@ -1,0 +1,28 @@
+package f3f.dev1.domain.tag.dao;
+
+import f3f.dev1.domain.post.model.Post;
+import f3f.dev1.domain.tag.model.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class PostTagCustomRepositoryImpl implements PostTagCustomRepository{
+
+  private final JdbcTemplate jdbcTemplate;
+  @Override
+  public void postTagBulkInsert(Long postId, List<Long> tagsId) {
+    String sql = "INSERT INTO post_tag (post_id, tag_id)\n"
+        + "SELECT (?), (?)\n"
+        + "WHERE NOT EXISTS (\n"
+        +"    SELECT 2 FROM post_tag WHERE tag_id = ?);";
+
+    jdbcTemplate.batchUpdate(sql, tagsId, tagsId.size(), (PreparedStatement ps, Long tagId) -> {
+      ps.setLong(1, postId);
+      ps.setLong(2, tagId);
+      ps.setLong(3, tagId);
+    });
+  }
+}

--- a/src/main/java/f3f/dev1/domain/tag/dao/PostTagCustomRepositoryImpl.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/PostTagCustomRepositoryImpl.java
@@ -13,11 +13,11 @@ public class PostTagCustomRepositoryImpl implements PostTagCustomRepository{
 
   private final JdbcTemplate jdbcTemplate;
   @Override
-  public void postTagBulkInsert(Long postId, List<Long> tagsId) {
+  public void savePostTagWithBulk(Long postId, List<Long> tagsId) {
     String sql = "INSERT INTO post_tag (post_id, tag_id)\n"
         + "SELECT (?), (?)\n"
         + "WHERE NOT EXISTS (\n"
-        +"    SELECT 2 FROM post_tag WHERE tag_id = ?);";
+        +"    SELECT 2 FROM post_tag WHERE tag_id = ?)";
 
     jdbcTemplate.batchUpdate(sql, tagsId, tagsId.size(), (PreparedStatement ps, Long tagId) -> {
       ps.setLong(1, postId);

--- a/src/main/java/f3f/dev1/domain/tag/dao/PostTagRepository.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/PostTagRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PostTagRepository extends JpaRepository<PostTag, Long> {
+public interface PostTagRepository extends JpaRepository<PostTag, Long>, PostTagCustomRepository {
 
     Optional<PostTag> findById(Long id);
     List<PostTag> findByTagName(String name);

--- a/src/main/java/f3f/dev1/domain/tag/dao/TagCustomRepository.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/TagCustomRepository.java
@@ -1,7 +1,9 @@
 package f3f.dev1.domain.tag.dao;
 
+import f3f.dev1.domain.tag.model.Tag;
+
 import java.util.List;
 
 public interface TagCustomRepository {
-  void tagBulkInsert(List<String> tagNames);
+  void saveTagWithBulk(List<String> tagNames);
 }

--- a/src/main/java/f3f/dev1/domain/tag/dao/TagCustomRepository.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/TagCustomRepository.java
@@ -1,0 +1,7 @@
+package f3f.dev1.domain.tag.dao;
+
+import java.util.List;
+
+public interface TagCustomRepository {
+  void tagBulkInsert(List<String> tagNames);
+}

--- a/src/main/java/f3f/dev1/domain/tag/dao/TagCustomRepositoryImpl.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/TagCustomRepositoryImpl.java
@@ -1,0 +1,26 @@
+package f3f.dev1.domain.tag.dao;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class TagCustomRepositoryImpl implements TagCustomRepository{
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Override
+  public void tagBulkInsert(List<String> tagNames) {
+    String sql = "INSERT INTO tag (name)\n"
+        + "SELECT ? \n"
+        + "WHERE NOT EXISTS (\n"
+        + "   SELECT 1 FROM tag where name = ?);";
+
+    jdbcTemplate.batchUpdate(sql, tagNames, tagNames.size(), (PreparedStatement ps, String tagName) -> {
+      ps.setString(1, tagName);
+      ps.setString(2, tagName);
+    });
+  }
+}

--- a/src/main/java/f3f/dev1/domain/tag/dao/TagCustomRepositoryImpl.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/TagCustomRepositoryImpl.java
@@ -10,13 +10,9 @@ import java.util.List;
 public class TagCustomRepositoryImpl implements TagCustomRepository{
 
   private final JdbcTemplate jdbcTemplate;
-
   @Override
-  public void tagBulkInsert(List<String> tagNames) {
-    String sql = "INSERT INTO tag (name)\n"
-        + "SELECT ? \n"
-        + "WHERE NOT EXISTS (\n"
-        + "   SELECT 1 FROM tag where name = ?);";
+  public void saveTagWithBulk(List<String> tagNames) {
+    String sql = "INSERT INTO tag (name) SELECT ? WHERE NOT EXISTS (SELECT 1 FROM tag where name = ?)";
 
     jdbcTemplate.batchUpdate(sql, tagNames, tagNames.size(), (PreparedStatement ps, String tagName) -> {
       ps.setString(1, tagName);

--- a/src/main/java/f3f/dev1/domain/tag/dao/TagRepository.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/TagRepository.java
@@ -3,6 +3,7 @@ package f3f.dev1.domain.tag.dao;
 import f3f.dev1.domain.tag.model.PostTag;
 import f3f.dev1.domain.tag.model.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/src/main/java/f3f/dev1/domain/tag/dao/TagRepository.java
+++ b/src/main/java/f3f/dev1/domain/tag/dao/TagRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface TagRepository extends JpaRepository<Tag, Long> {
+public interface TagRepository extends JpaRepository<Tag, Long>, TagCustomRepository {
 
     Optional<Tag> findById(Long id);
     Optional<Tag> findByName(String name);

--- a/src/main/java/f3f/dev1/domain/tag/model/PostTag.java
+++ b/src/main/java/f3f/dev1/domain/tag/model/PostTag.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 public class PostTag {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "postTag_id")
     private Long id;
 

--- a/src/main/java/f3f/dev1/domain/tag/model/Tag.java
+++ b/src/main/java/f3f/dev1/domain/tag/model/Tag.java
@@ -8,11 +8,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
 @Entity
+@NoArgsConstructor
+@Table(indexes = @Index(name = "idx__tag_name", columnList = "name"))
 public class Tag {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "tag_id")
     private Long id;
 


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 태그 생성 시 벌크연산 수행
     - 다량의 데이터를 삽입하는 데 더 최적화
     - 기존 방식의 경우 많은 트래픽이 한순간 몰리면 태그명이 중복되어 데이터베이스에 삽입되는 문제 발생
     - 벌크연산 방식으로 수정하여 오류 수정 및 테스트 완료

#### 기존 방식 테스트 결과
<img width="1377" alt="image" src="https://github.com/Owen-Choi/COKIRI/assets/82303989/0dee0cf1-1ff9-4378-9459-b17210c6d1ad">

=> savePost 요청의 오류 발생율 58%

#### 리팩토링 후 테스트 결과
<img width="1382" alt="image" src="https://github.com/Owen-Choi/COKIRI/assets/82303989/392e4720-9bca-4ea8-a98e-eff4f0482f35">

=> savePost 요청의 오류 발생율 0.08%