### PR TITLE
게시글 태그 검색 리팩토링

### DIFF
--- a/src/main/java/f3f/dev1/domain/post/dao/PostCustomRepository.java
+++ b/src/main/java/f3f/dev1/domain/post/dao/PostCustomRepository.java
@@ -14,7 +14,7 @@ import static f3f.dev1.domain.post.dto.PostDTO.*;
 
 public interface PostCustomRepository {
     Page<Post> findPostDTOByConditions(SearchPostRequestExcludeTag requestExcludeTag, Pageable pageable);
-    Page<Post> findPostsByTags(List<String> tagNames, TradeStatus tradeStatus, Pageable pageable);
+    Page<PostSearchResponseDto> findPostsByTags(List<String> tagNames, TradeStatus tradeStatus, Pageable pageable);
     Page<Post> findPostsWithTradeStatus(TradeStatus tradeStatus, Pageable pageable);
 
     Page<MemberDTO.GetUserPost> getUserPostById(Long memberId, Pageable pageable);

--- a/src/main/java/f3f/dev1/domain/post/dao/PostRepository.java
+++ b/src/main/java/f3f/dev1/domain/post/dao/PostRepository.java
@@ -28,28 +28,4 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
     void deleteById(Long id);
     Page<Post> findAll(Pageable pageable);
 
-//    @Query(value = "SELECT p.post_id AS postId, p.title, p.thumbnail_img_path AS thumbnail, t.trade_status AS tradeStatus, c.name, count(sp.scrap_id) AS likes " +
-//            "FROM post p "+
-//            "LEFT JOIN scrap_post sp on p.post_id = sp.post_id "+
-//            "JOIN trade t on p.post_id = t.post_id "+
-//            "JOIN category c on c.category_id = p.wish_category_id "+
-//            "WHERE p.member_id = :userId " +
-//            "GROUP BY p.post_id",countQuery = "SELECT count(*) FROM post p WHERE p.member_id = :userId ", nativeQuery = true)
-//    Page<GetUserPostInterface> getUserPostById(@Param(value = "userId") Long userId, Pageable pageable);
-//
-//
-//    interface GetUserPostInterface {
-//        Long getPostId();
-//
-//        String getTitle();
-//
-//        String getThumbnail();
-//
-//        String getTradeStatus();
-//
-//        String getName();
-//
-//        Long getLikes();
-//
-//    }
 }

--- a/src/main/java/f3f/dev1/domain/post/dto/PostDTO.java
+++ b/src/main/java/f3f/dev1/domain/post/dto/PostDTO.java
@@ -12,6 +12,7 @@ import lombok.*;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static f3f.dev1.domain.comment.dto.CommentDTO.*;
@@ -180,9 +181,26 @@ public class PostDTO {
         private String createdTime;
         private Long messageRoomCount;
         private String wishCategory;
-        private boolean isScrap;
+        private Boolean isScrap;
         private Long scrapCount;
         private Long price;
+
+        public PostSearchResponseDto(Long id, String title, String content, String thumbnail, String authorNickname,
+                                     String productCategory, LocalDateTime createdTime, Long messageRoomCount,
+                                     String wishCategory, boolean isScrap, Long scrapCount, Long price) {
+            this.id = id;
+            this.title = title;
+            this.price = price;
+            this.content = content;
+            this.isScrap = isScrap;
+            this.thumbnail = thumbnail;
+            this.scrapCount = scrapCount;
+            this.wishCategory = wishCategory;
+            this.authorNickname = authorNickname;
+            this.productCategory = productCategory;
+            this.messageRoomCount = messageRoomCount;
+            this.createdTime = createdTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
+        }
     }
 
     @Getter


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 게시글 태그 검색 리팩토링
     - 애플리케이션 로직을 태워 반복문 + 다수의 쿼리로 해결하던 기존 로직을
     - QueryDSL Projection과 default_batch_fetch_size 를 통해 해결하도록 수정
